### PR TITLE
Update JWT key and add EF Core tests

### DIFF
--- a/LEMP.Api/Controllers/AuthController.cs
+++ b/LEMP.Api/Controllers/AuthController.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+
+namespace LEMP.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class AuthController : ControllerBase
+{
+    private readonly IConfiguration _config;
+
+    public AuthController(IConfiguration config)
+    {
+        _config = config;
+    }
+
+    [HttpPost("login")]
+    public IActionResult Login([FromBody] LoginDto dto)
+    {
+        if (dto.Username == "admin" && dto.Password == "password")
+        {
+            var token = GenerateToken();
+            return Ok(new { token });
+        }
+
+        return Unauthorized();
+    }
+
+    private string GenerateToken()
+    {
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_config["Jwt:Key"]!));
+        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+        var token = new JwtSecurityToken(
+            issuer: _config["Jwt:Issuer"],
+            audience: _config["Jwt:Issuer"],
+            claims: new[] { new Claim(ClaimTypes.Name, "admin") },
+            expires: DateTime.UtcNow.AddHours(1),
+            signingCredentials: creds);
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    public record LoginDto(string Username, string Password);
+}

--- a/LEMP.Api/Controllers/MeasurementController.cs
+++ b/LEMP.Api/Controllers/MeasurementController.cs
@@ -1,9 +1,11 @@
-﻿using LEMP.Application.DTOs;
+using LEMP.Application.DTOs;
 using LEMP.Application.Interfaces;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace LEMP.Api.Controllers;
 
+[Authorize]
 [ApiController]
 [Route("api/[controller]")]
 public class MeasurementController : ControllerBase

--- a/LEMP.Api/LEMP.Api.csproj
+++ b/LEMP.Api/LEMP.Api.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.34.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LEMP.Api/Program.cs
+++ b/LEMP.Api/Program.cs
@@ -2,6 +2,9 @@
 using LEMP.Infrastructure.Data;
 using LEMP.Infrastructure.Services;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -13,12 +16,30 @@ builder.Services.AddDbContext<MeasurementDbContext>(options =>
     options.UseNpgsql(builder.Configuration.GetConnectionString("Default")));
 builder.Services.AddScoped<IMeasurementService, EfMeasurementService>();
 
+builder.Services
+    .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidateAudience = true,
+            ValidateLifetime = true,
+            ValidateIssuerSigningKey = true,
+            ValidIssuer = builder.Configuration["Jwt:Issuer"],
+            ValidAudience = builder.Configuration["Jwt:Issuer"],
+            IssuerSigningKey = new SymmetricSecurityKey(
+                Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"]!))
+        };
+    });
+
 var app = builder.Build();
 
 app.UseSwagger();
 app.UseSwaggerUI();
 
 app.UseHttpsRedirection();
+app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapControllers();

--- a/LEMP.Api/appsettings.Development.json
+++ b/LEMP.Api/appsettings.Development.json
@@ -7,5 +7,9 @@
   },
   "ConnectionStrings": {
     "Default": "Host=localhost;Port=5432;Database=lemp;Username=postgres;Password=50NagyAlma"
+  },
+  "Jwt": {
+    "Key": "feakTaxiSecretKey",
+    "Issuer": "LempApi"
   }
 }

--- a/LEMP.Api/appsettings.json
+++ b/LEMP.Api/appsettings.json
@@ -8,5 +8,9 @@
   "ConnectionStrings": {
     "Default": "Host=localhost;Port=5432;Database=lemp;Username=postgres;Password=50NagyAlma"
   },
+  "Jwt": {
+    "Key": "feakTaxiSecretKey",
+    "Issuer": "LempApi"
+  },
   "AllowedHosts": "*"
 }

--- a/LEMP.Test/EfMeasurementServiceTests.cs
+++ b/LEMP.Test/EfMeasurementServiceTests.cs
@@ -1,0 +1,32 @@
+using LEMP.Application.DTOs;
+using LEMP.Infrastructure.Data;
+using LEMP.Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+
+namespace LEMP.Test;
+
+public class EfMeasurementServiceTests
+{
+    [Test]
+    public async Task AddAndRetrieveMeasurementsFromDb()
+    {
+        var options = new DbContextOptionsBuilder<MeasurementDbContext>()
+            .UseInMemoryDatabase("measurements")
+            .Options;
+
+        await using var context = new MeasurementDbContext(options);
+        var service = new EfMeasurementService(context);
+
+        await service.AddMeasurementAsync(new MeasurementDto
+        {
+            SourceType = "Test",
+            SourceId = "1",
+            Timestamp = DateTime.UtcNow,
+            Values = new() { ["v"] = 1 }
+        });
+
+        var all = await service.GetAllAsync();
+        Assert.AreEqual(1, all.Count());
+    }
+}

--- a/LEMP.Test/LEMP.Test.csproj
+++ b/LEMP.Test/LEMP.Test.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LEMP.Test/MeasurementServiceTests.cs
+++ b/LEMP.Test/MeasurementServiceTests.cs
@@ -1,0 +1,36 @@
+using LEMP.Application.DTOs;
+using LEMP.Infrastructure.Data;
+using LEMP.Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+
+namespace LEMP.Test;
+
+public class MeasurementServiceTests
+{
+    [Test]
+    public async Task AddMeasurementsEveryFiveSeconds()
+    {
+        var options = new DbContextOptionsBuilder<MeasurementDbContext>()
+            .UseInMemoryDatabase("five-second")
+            .Options;
+        await using var context = new MeasurementDbContext(options);
+        var service = new EfMeasurementService(context);
+
+        for (int i = 0; i < 2; i++)
+        {
+            await service.AddMeasurementAsync(new MeasurementDto
+            {
+                SourceType = "Test",
+                SourceId = i.ToString(),
+                Timestamp = DateTime.UtcNow,
+                Values = new() { ["v"] = i }
+            });
+
+            await Task.Delay(TimeSpan.FromSeconds(5));
+        }
+
+        var all = await service.GetAllAsync();
+        Assert.AreEqual(2, all.Count());
+    }
+}


### PR DESCRIPTION
## Summary
- change JWT key to `feakTaxiSecretKey`
- enable EF Core in-memory provider for tests
- update measurement service test to use database
- add new unit test for `EfMeasurementService`

## Testing
- `dotnet test LEMP.sln` *(fails: `dotnet` not found)*


------
https://chatgpt.com/codex/tasks/task_e_6867bb874294832d9beab24df831a252