### PR TITLE
Use Assert.That in tests

### DIFF
--- a/LEMP.Test/EfMeasurementServiceTests.cs
+++ b/LEMP.Test/EfMeasurementServiceTests.cs
@@ -27,6 +27,6 @@ public class EfMeasurementServiceTests
         });
 
         var all = await service.GetAllAsync();
-        Assert.AreEqual(1, all.Count());
+        Assert.That(all.Count(), Is.EqualTo(1));
     }
 }

--- a/LEMP.Test/MeasurementServiceTests.cs
+++ b/LEMP.Test/MeasurementServiceTests.cs
@@ -31,6 +31,6 @@ public class MeasurementServiceTests
         }
 
         var all = await service.GetAllAsync();
-        Assert.AreEqual(2, all.Count());
+        Assert.That(all.Count(), Is.EqualTo(2));
     }
 }


### PR DESCRIPTION
## Summary
- replace classic Assert.AreEqual with Assert.That
- update assertions in measurement tests

## Testing
- `dotnet test LEMP.Test/LEMP.Test.csproj` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867c5332f68832d9f435ede89ea4fa0