### PR TITLE
Update Jwt package

### DIFF
--- a/LEMP.Api/LEMP.Api.csproj
+++ b/LEMP.Api/LEMP.Api.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.34.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.0.3" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- bump System.IdentityModel.Tokens.Jwt to 7.0.3 in the API project

## Testing
- `dotnet restore LEMP.sln` *(fails: dotnet not found)*
- `dotnet build LEMP.sln -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867e4b510a4832d9f2f959ebc3f7294