### PR TITLE
Fix Jwt token library version

### DIFF
--- a/LEMP.Api/LEMP.Api.csproj
+++ b/LEMP.Api/LEMP.Api.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.34.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.0.3" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- update `System.IdentityModel.Tokens.Jwt` to version 7.0.3

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867f55684dc832dbd45c16139d423ef