### PR TITLE
Add extended unit tests

### DIFF
--- a/LEMP.Test/EfTwoFactorServiceTests.cs
+++ b/LEMP.Test/EfTwoFactorServiceTests.cs
@@ -1,0 +1,49 @@
+using LEMP.Infrastructure.Data;
+using LEMP.Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+
+namespace LEMP.Test;
+
+public class EfTwoFactorServiceTests
+{
+    private static MeasurementDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<MeasurementDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new MeasurementDbContext(options);
+    }
+
+    private static IConfiguration CreateConfig()
+    {
+        var dict = new Dictionary<string, string> { { "EncryptionKey", "my-test-key" } };
+        return new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+    }
+
+    [Test]
+    public async Task SetAndGetSecretAsync()
+    {
+        await using var context = CreateContext();
+        var service = new EfTwoFactorService(context, CreateConfig());
+
+        await service.SetSecretAsync("user1", "SECRET");
+
+        var entry = await context.TwoFactorSecrets.SingleAsync(e => e.Username == "user1");
+        Assert.That(entry.EncryptedSecret, Is.Not.EqualTo("SECRET"));
+
+        var retrieved = await service.GetSecretAsync("user1");
+        Assert.That(retrieved, Is.EqualTo("SECRET"));
+    }
+
+    [Test]
+    public async Task GetSecretReturnsNullForUnknownUser()
+    {
+        await using var context = CreateContext();
+        var service = new EfTwoFactorService(context, CreateConfig());
+
+        var result = await service.GetSecretAsync("unknown");
+        Assert.That(result, Is.Null);
+    }
+}

--- a/LEMP.Test/EncryptionUtilityTests.cs
+++ b/LEMP.Test/EncryptionUtilityTests.cs
@@ -1,0 +1,20 @@
+using LEMP.Infrastructure.Services;
+using NUnit.Framework;
+
+namespace LEMP.Test;
+
+public class EncryptionUtilityTests
+{
+    [Test]
+    public void EncryptAndDecryptRoundTrip()
+    {
+        const string text = "secret-data";
+        const string key = "encryption-key";
+
+        var encrypted = EncryptionUtility.Encrypt(text, key);
+        Assert.That(encrypted, Is.Not.EqualTo(text));
+
+        var decrypted = EncryptionUtility.Decrypt(encrypted, key);
+        Assert.That(decrypted, Is.EqualTo(text));
+    }
+}

--- a/LEMP.Test/FakeMeasurementServiceTests.cs
+++ b/LEMP.Test/FakeMeasurementServiceTests.cs
@@ -1,0 +1,27 @@
+using LEMP.Application.DTOs;
+using LEMP.Infrastructure.Services;
+using NUnit.Framework;
+
+namespace LEMP.Test;
+
+public class FakeMeasurementServiceTests
+{
+    [Test]
+    public async Task AddAndRetrieveMeasurements()
+    {
+        var service = new FakeMeasurementService();
+
+        var dto = new MeasurementDto
+        {
+            SourceType = "Test",
+            SourceId = "1",
+            Timestamp = DateTime.UtcNow,
+            Values = new() { ["a"] = 1.2 }
+        };
+
+        await service.AddMeasurementAsync(dto);
+
+        var all = await service.GetAllAsync();
+        Assert.That(all.Single().SourceId, Is.EqualTo("1"));
+    }
+}

--- a/LEMP.Test/LEMP.Test.csproj
+++ b/LEMP.Test/LEMP.Test.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LEMP.Test/TotpGeneratorTests.cs
+++ b/LEMP.Test/TotpGeneratorTests.cs
@@ -1,0 +1,44 @@
+using LEMP.Application.Utils;
+using NUnit.Framework;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace LEMP.Test;
+
+public class TotpGeneratorTests
+{
+    private static string GenerateCode(string secret, int offset = 0)
+    {
+        var timestep = DateTimeOffset.UtcNow.ToUnixTimeSeconds() / 30 + offset;
+        var data = BitConverter.GetBytes(timestep);
+        if (BitConverter.IsLittleEndian)
+            Array.Reverse(data);
+
+        var key = Encoding.ASCII.GetBytes(secret);
+        using var hmac = new HMACSHA1(key);
+        var hash = hmac.ComputeHash(data);
+        int start = hash[^1] & 0x0F;
+        int binary = ((hash[start] & 0x7F) << 24)
+                    | (hash[start + 1] << 16)
+                    | (hash[start + 2] << 8)
+                    | (hash[start + 3]);
+        int otp = binary % 1_000_000;
+        return otp.ToString("D6");
+    }
+
+    [Test]
+    public void VerifyReturnsTrueForValidCode()
+    {
+        const string secret = "TESTSECRET";
+        var code = GenerateCode(secret);
+        Assert.That(TotpGenerator.Verify(secret, code), Is.True);
+    }
+
+    [Test]
+    public void VerifyReturnsFalseForInvalidCode()
+    {
+        const string secret = "TESTSECRET";
+        var code = GenerateCode(secret, 2); // offset outside default window
+        Assert.That(TotpGenerator.Verify(secret, code), Is.False);
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for TOTP verification, encryption, two-factor service and fake measurement service
- include configuration package for test project

## Testing
- `dotnet test LEMP.Test/LEMP.Test.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_686fcfb02804832d89bb92cb3b15218a