### PR TITLE
Fix SQL verbatim strings in tests

### DIFF
--- a/LEMP.Test/EfMeasurementServiceTests.cs
+++ b/LEMP.Test/EfMeasurementServiceTests.cs
@@ -19,16 +19,16 @@ public class EfMeasurementServiceTests
 
     private static async Task EnsureSchemaAsync(MeasurementDbContext context)
     {
-        var sql = @"CREATE TABLE IF NOT EXISTS \"Measurements\" (
-                        \"Id\" SERIAL PRIMARY KEY,
-                        \"SourceType\" TEXT NOT NULL,
-                        \"SourceId\" TEXT NOT NULL,
-                        \"Timestamp\" TIMESTAMPTZ NOT NULL,
-                        \"Values\" TEXT NOT NULL);
-                    CREATE TABLE IF NOT EXISTS \"TwoFactorSecrets\" (
-                        \"Id\" SERIAL PRIMARY KEY,
-                        \"Username\" TEXT NOT NULL,
-                        \"EncryptedSecret\" TEXT NOT NULL);";
+        var sql = @"CREATE TABLE IF NOT EXISTS ""Measurements"" (
+                        ""Id"" SERIAL PRIMARY KEY,
+                        ""SourceType"" TEXT NOT NULL,
+                        ""SourceId"" TEXT NOT NULL,
+                        ""Timestamp"" TIMESTAMPTZ NOT NULL,
+                        ""Values"" TEXT NOT NULL);
+                    CREATE TABLE IF NOT EXISTS ""TwoFactorSecrets"" (
+                        ""Id"" SERIAL PRIMARY KEY,
+                        ""Username"" TEXT NOT NULL,
+                        ""EncryptedSecret"" TEXT NOT NULL);";
         await context.Database.ExecuteSqlRawAsync(sql);
     }
 

--- a/LEMP.Test/EfTwoFactorServiceTests.cs
+++ b/LEMP.Test/EfTwoFactorServiceTests.cs
@@ -23,16 +23,16 @@ public class EfTwoFactorServiceTests
 
     private static void EnsureSchema(MeasurementDbContext context)
     {
-        const string sql = @"CREATE TABLE IF NOT EXISTS \"Measurements\" (
-                                \"Id\" SERIAL PRIMARY KEY,
-                                \"SourceType\" TEXT NOT NULL,
-                                \"SourceId\" TEXT NOT NULL,
-                                \"Timestamp\" TIMESTAMPTZ NOT NULL,
-                                \"Values\" TEXT NOT NULL);
-                            CREATE TABLE IF NOT EXISTS \"TwoFactorSecrets\" (
-                                \"Id\" SERIAL PRIMARY KEY,
-                                \"Username\" TEXT NOT NULL,
-                                \"EncryptedSecret\" TEXT NOT NULL);";
+        const string sql = @"CREATE TABLE IF NOT EXISTS ""Measurements"" (
+                                ""Id"" SERIAL PRIMARY KEY,
+                                ""SourceType"" TEXT NOT NULL,
+                                ""SourceId"" TEXT NOT NULL,
+                                ""Timestamp"" TIMESTAMPTZ NOT NULL,
+                                ""Values"" TEXT NOT NULL);
+                            CREATE TABLE IF NOT EXISTS ""TwoFactorSecrets"" (
+                                ""Id"" SERIAL PRIMARY KEY,
+                                ""Username"" TEXT NOT NULL,
+                                ""EncryptedSecret"" TEXT NOT NULL);";
         context.Database.ExecuteSqlRaw(sql);
     }
 


### PR DESCRIPTION
## Summary
- fix quoting for SQL strings in `EfMeasurementServiceTests`
- fix quoting for SQL strings in `EfTwoFactorServiceTests`

## Testing
- `dotnet test` *(fails: SocketException due to DB connection)*

------
https://chatgpt.com/codex/tasks/task_e_68711c040234832dbd2031bf9c07b5bc