### PR TITLE
Refactor Program into clean Web API

### DIFF
--- a/LEMP.Api/Controllers/DataPointController.cs
+++ b/LEMP.Api/Controllers/DataPointController.cs
@@ -1,45 +1,97 @@
-//using LEMP.Application.Interfaces;
-//using LEMP.Domain.DataPoints;
-//using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using InfluxDB3.Client;
+using InfluxDB3.Client.Write;
+using LEMP.Api.Models;
+using Microsoft.AspNetCore.Mvc;
 
-//namespace LEMP.Api.Controllers;
+namespace LEMP.Api.Controllers
+{
+    /// <summary>
+    /// API endpoints for reading and writing InfluxDB datapoints.
+    /// </summary>
+    [ApiController]
+    [Route("api/[controller]")]
+    public class DataPointController : ControllerBase
+    {
+        private readonly InfluxDBClient _client;
 
-//[ApiController]
-//[Route("api/[controller]")]
-//public class DataPointController : ControllerBase
-//{
-//    private readonly IDataPointService _service;
+        /// <summary>
+        /// Initializes a new instance of <see cref="DataPointController"/>.
+        /// </summary>
+        /// <param name="client">InfluxDB client instance.</param>
+        public DataPointController(InfluxDBClient client)
+        {
+            _client = client;
+        }
 
-//    public DataPointController(IDataPointService service)
-//    {
-//        _service = service;
-//    }
+        /// <summary>
+        /// Gets the latest datapoints for a measurement.
+        /// </summary>
+        /// <param name="measurement">Measurement name.</param>
+        /// <param name="limit">Number of points to return.</param>
+        /// <returns>Collection of rows from InfluxDB.</returns>
+        [HttpGet]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> Get([FromQuery] string measurement, [FromQuery] int limit = 10)
+        {
+            if (string.IsNullOrWhiteSpace(measurement))
+            {
+                return BadRequest("measurement query parameter is required");
+            }
 
-//    [HttpPost("inverter")]
-//    public async Task<IActionResult> PostInverter([FromBody] InverterDataPoint point)
-//    {
-//        await _service.WriteAsync(point);
-//        return Ok();
-//    }
+            var sql = $"select * from {measurement} order by time desc limit {limit}";
+            var rows = new List<object[]>();
+            await foreach (var row in _client.Query(query: sql))
+            {
+                rows.Add(row);
+            }
 
-//    [HttpPost("bms")]
-//    public async Task<IActionResult> PostBms([FromBody] BmsDataPoint point)
-//    {
-//        await _service.WriteAsync(point);
-//        return Ok();
-//    }
+            return Ok(rows);
+        }
 
-//    [HttpPost("smartmeter")]
-//    public async Task<IActionResult> PostSmartMeter([FromBody] SmartMeterDataPoint point)
-//    {
-//        await _service.WriteAsync(point);
-//        return Ok();
-//    }
+        /// <summary>
+        /// Writes a datapoint to InfluxDB.
+        /// </summary>
+        /// <param name="dto">Datapoint payload.</param>
+        [HttpPost]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> Post([FromBody] DataPointDto dto)
+        {
+            if (dto == null || string.IsNullOrWhiteSpace(dto.Measurement))
+            {
+                return BadRequest("Measurement is required");
+            }
 
-//    [HttpPost("meta")]
-//    public async Task<IActionResult> PostMeta([FromBody] MetaDataPoint point)
-//    {
-//        await _service.WriteAsync(point);
-//        return Ok();
-//    }
-//}
+            var point = PointData.Measurement(dto.Measurement);
+            if (dto.Tags != null)
+            {
+                foreach (var tag in dto.Tags)
+                {
+                    point = point.SetTag(tag.Key, tag.Value);
+                }
+            }
+
+            if (dto.Fields != null)
+            {
+                foreach (var field in dto.Fields)
+                {
+                    point = point.SetField(field.Key, field.Value);
+                }
+            }
+
+            if (dto.Timestamp.HasValue)
+            {
+                point = point.SetTimestamp(dto.Timestamp.Value);
+            }
+
+            await _client.WritePointAsync(point);
+            return CreatedAtAction(nameof(Get), new { measurement = dto.Measurement, limit = 1 }, null);
+        }
+    }
+}
+

--- a/LEMP.Api/Models/DataPointDto.cs
+++ b/LEMP.Api/Models/DataPointDto.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+
+namespace LEMP.Api.Models
+{
+    /// <summary>
+    /// Represents a generic InfluxDB data point.
+    /// </summary>
+    public class DataPointDto
+    {
+        /// <summary>
+        /// Measurement name for the point.
+        /// </summary>
+        public string Measurement { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Tags associated with the point.
+        /// </summary>
+        public IDictionary<string, string>? Tags { get; set; }
+
+        /// <summary>
+        /// Fields of the point.
+        /// </summary>
+        public IDictionary<string, object>? Fields { get; set; }
+
+        /// <summary>
+        /// Optional timestamp for the point.
+        /// </summary>
+        public DateTime? Timestamp { get; set; }
+    }
+}

--- a/LEMP.Api/Program.cs
+++ b/LEMP.Api/Program.cs
@@ -1,144 +1,32 @@
-﻿// NuGet packages:
-// dotnet add package InfluxDB3.Client
-// dotnet add package Microsoft.Extensions.Http
+using LEMP.Infrastructure.Extensions;
+using LEMP.Infrastructure.Services;
+using Microsoft.OpenApi.Models;
 
-using System;
-using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Text;
-using System.Text.Json;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
+var builder = WebApplication.CreateBuilder(args);
 
-namespace LEMP.Api
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(c =>
 {
-    public class Program
-    {
-        public static async Task Main(string[] args)
-        {
-            Console.WriteLine("Starting application...");
-            var builder = WebApplication.CreateBuilder(args);
+    c.SwaggerDoc("v1", new OpenApiInfo { Title = "LEMP API", Version = "v1" });
+});
 
-            // Configuration
-            var influx = builder.Configuration.GetSection("InfluxDB");
-            var host = influx["Host"] ?? "localhost";
-            var port = int.Parse(influx["Port"] ?? "8181");
-            var token = influx["Token"] ?? string.Empty;
-            var bucket = influx["Bucket"] ?? string.Empty;
-            var org = influx["Org"] ?? string.Empty;
-            var node = influx["NodeId"] ?? string.Empty;
-            Console.WriteLine($"Config: host={host}, port={port}, bucket={bucket}, org={org}, node={node}");
-            var baseUri = new UriBuilder("http", host, port).Uri;
+builder.Services.AddInfluxDbClient(builder.Configuration);
+builder.Services.AddInfluxRawHttpClient(builder.Configuration);
 
-            // HttpClient DI
-            builder.Services.AddHttpClient("Influx", c =>
-            {
-                c.BaseAddress = baseUri;
-                c.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            });
+// Service hosting raw HTTP tests if needed.
+builder.Services.AddTransient<InfluxRawTestService>();
 
-            var app = builder.Build();
-            Console.WriteLine("Running API tests:");
-            await RunTests(app.Services, bucket, org, node);
+var app = builder.Build();
 
-            Console.WriteLine("Starting web host...");
-            app.Run();
-        }
-
-        private static async Task RunTests(IServiceProvider sp, string bucket, string org, string node)
-        {
-            var client = sp.GetRequiredService<IHttpClientFactory>().CreateClient("Influx");
-
-            // 1) Write line protocol to database
-
-            var writeUrl = $"/api/v3/write_lp?db={Uri.EscapeDataString(bucket)}&org={Uri.EscapeDataString(org)}&precision=ns";
-
-            await Test(client, HttpMethod.Post, writeUrl, "test,tag=example value=123", "text/plain");
-
-            // 2) Query SQL via POST
-            var sqlBody = JsonSerializer.Serialize(new
-            {
-
-                db = bucket,
-                query = "SELECT * FROM test LIMIT 1",
-                format = "json"
-
-            });
-            await Test(client, HttpMethod.Post, "/api/v3/query/sql", sqlBody);
-
-            // 3) Query InfluxQL via POST
-            var influxqlBody = JsonSerializer.Serialize(new
-            {
-
-                db = bucket,
-                query = "SELECT * FROM test LIMIT 1",
-                format = "json"
-
-            });
-            await Test(client, HttpMethod.Post, "/api/v3/query/influxql", influxqlBody);
-
-            // 4) Health, Ping, Metrics (no auth params)
-            await Test(client, HttpMethod.Get, "/health");
-            await Test(client, HttpMethod.Get, "/ping");
-            await Test(client, HttpMethod.Get, "/metrics");
-
-            // 5) Database configuration
-
-            await Test(client, HttpMethod.Get, "/api/v3/configure/database?db=" + Uri.EscapeDataString(bucket));
-            var dbBody = JsonSerializer.Serialize(new { db = bucket, org });
-            await Test(client, HttpMethod.Post, "/api/v3/configure/database", dbBody);
-            await Test(client, HttpMethod.Delete, "/api/v3/configure/database?db=" + Uri.EscapeDataString(bucket));
-
-            // 6) Table configuration
-            var tblBody = JsonSerializer.Serialize(new
-            {
-                db = bucket,
-                table = "test_table",
-
-                columns = new[]
-                {
-                    new { name = "_time", type = "timestamp" },
-                    new { name = "value", type = "double" }
-                }
-
-            });
-            await Test(client, HttpMethod.Post, "/api/v3/configure/table", tblBody);
-            await Test(client, HttpMethod.Delete, "/api/v3/configure/table?db=" + Uri.EscapeDataString(bucket) + "&table=test_table");
-
-            // 7) Plugin environment install packages
-            var pkgBody = JsonSerializer.Serialize(new { packages = new[] { "influxdb3-python" } });
-            await Test(client, HttpMethod.Post, "/api/v3/configure/plugin_environment/install_packages", pkgBody);
-
-            // 8) List tokens via SQL
-            var tokenBody = JsonSerializer.Serialize(new
-            {
-
-                db = "_internal",
-                query = "SELECT id, name, permissions FROM system.tokens",
-                format = "json"
-
-            });
-            await Test(client, HttpMethod.Post, "/api/v3/query/sql", tokenBody);
-        }
-
-        private static async Task Test(HttpClient client, HttpMethod method, string path, string? body = null, string media = "application/json")
-        {
-            HttpResponseMessage res;
-            if (method == HttpMethod.Get)
-            {
-                res = await client.GetAsync(path);
-            }
-            else
-            {
-                var req = new HttpRequestMessage(method, path);
-                if (body != null)
-                    req.Content = new StringContent(body, Encoding.UTF8, media);
-                res = await client.SendAsync(req);
-            }
-            Console.WriteLine($"[Test] {method.Method} {path} -> {res.StatusCode}");
-        }
-    }
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
 }
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/LEMP.Infrastructure/Extensions/InfluxServiceCollectionExtensions.cs
+++ b/LEMP.Infrastructure/Extensions/InfluxServiceCollectionExtensions.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Net.Http.Headers;
+using InfluxDB3.Client;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LEMP.Infrastructure.Extensions
+{
+    /// <summary>
+    /// Extension methods for registering InfluxDB related services.
+    /// </summary>
+    public static class InfluxServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Registers <see cref="InfluxDBClient"/> for dependency injection.
+        /// </summary>
+        /// <param name="services">Service collection.</param>
+        /// <param name="configuration">Application configuration.</param>
+        /// <returns>The modified service collection.</returns>
+        public static IServiceCollection AddInfluxDbClient(this IServiceCollection services, IConfiguration configuration)
+        {
+            var influx = configuration.GetSection("InfluxDB");
+            var host = influx["Host"] ?? "localhost";
+            var port = int.Parse(influx["Port"] ?? "8181");
+            var token = influx["Token"] ?? string.Empty;
+            var bucket = influx["Bucket"] ?? string.Empty;
+
+            var url = new UriBuilder("http", host, port).ToString();
+            services.AddSingleton(_ => new InfluxDBClient(url, token: token, database: bucket));
+            return services;
+        }
+
+        /// <summary>
+        /// Registers a raw HTTP <see cref="HttpClient"/> for InfluxDB requests.
+        /// </summary>
+        /// <param name="services">Service collection.</param>
+        /// <param name="configuration">Application configuration.</param>
+        /// <returns>The modified service collection.</returns>
+        public static IServiceCollection AddInfluxRawHttpClient(this IServiceCollection services, IConfiguration configuration)
+        {
+            var influx = configuration.GetSection("InfluxDB");
+            var host = influx["Host"] ?? "localhost";
+            var port = int.Parse(influx["Port"] ?? "8181");
+            var token = influx["Token"] ?? string.Empty;
+
+            var baseUri = new UriBuilder("http", host, port).Uri;
+
+            services.AddHttpClient("Influx", c =>
+            {
+                c.BaseAddress = baseUri;
+                c.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            });
+
+            return services;
+        }
+    }
+}

--- a/LEMP.Infrastructure/LEMP.Infrastructure.csproj
+++ b/LEMP.Infrastructure/LEMP.Infrastructure.csproj
@@ -13,6 +13,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="InfluxDB3.Client" Version="1.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Services\" />

--- a/LEMP.Infrastructure/Services/InfluxRawTestService.cs
+++ b/LEMP.Infrastructure/Services/InfluxRawTestService.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace LEMP.Infrastructure.Services
+{
+    /// <summary>
+    /// Executes raw HTTP calls against the InfluxDB API for testing purposes.
+    /// </summary>
+    public class InfluxRawTestService
+    {
+        private readonly IHttpClientFactory _factory;
+        private readonly IConfiguration _configuration;
+        private readonly ILogger<InfluxRawTestService> _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InfluxRawTestService"/> class.
+        /// </summary>
+        public InfluxRawTestService(IHttpClientFactory factory, IConfiguration configuration, ILogger<InfluxRawTestService> logger)
+        {
+            _factory = factory;
+            _configuration = configuration;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Executes all raw HTTP tests.
+        /// </summary>
+        public async Task RunAsync()
+        {
+            var client = _factory.CreateClient("Influx");
+            var bucket = _configuration["InfluxDB:Bucket"] ?? string.Empty;
+            var org = _configuration["InfluxDB:Org"] ?? string.Empty;
+
+            await WriteLineProtocolAsync(client, bucket, org);
+            await QuerySqlAsync(client, bucket);
+            await QueryInfluxQlAsync(client, bucket);
+            await CheckHealthAsync(client);
+            await ConfigureDatabaseAsync(client, bucket, org);
+            await ConfigureTableAsync(client, bucket);
+            await InstallPackagesAsync(client);
+            await ListTokensAsync(client);
+        }
+
+        private async Task WriteLineProtocolAsync(HttpClient client, string bucket, string org)
+        {
+            var url = $"/api/v3/write_lp?db={Uri.EscapeDataString(bucket)}&org={Uri.EscapeDataString(org)}&precision=ns";
+            await SendAsync(client, HttpMethod.Post, url, "test,tag=example value=123", "text/plain");
+        }
+
+        private async Task QuerySqlAsync(HttpClient client, string bucket)
+        {
+            var body = JsonSerializer.Serialize(new { db = bucket, query = "SELECT * FROM test LIMIT 1", format = "json" });
+            await SendAsync(client, HttpMethod.Post, "/api/v3/query/sql", body);
+        }
+
+        private async Task QueryInfluxQlAsync(HttpClient client, string bucket)
+        {
+            var body = JsonSerializer.Serialize(new { db = bucket, query = "SELECT * FROM test LIMIT 1", format = "json" });
+            await SendAsync(client, HttpMethod.Post, "/api/v3/query/influxql", body);
+        }
+
+        private async Task CheckHealthAsync(HttpClient client)
+        {
+            await SendAsync(client, HttpMethod.Get, "/health");
+            await SendAsync(client, HttpMethod.Get, "/ping");
+            await SendAsync(client, HttpMethod.Get, "/metrics");
+        }
+
+        private async Task ConfigureDatabaseAsync(HttpClient client, string bucket, string org)
+        {
+            await SendAsync(client, HttpMethod.Get, $"/api/v3/configure/database?db={Uri.EscapeDataString(bucket)}");
+            var body = JsonSerializer.Serialize(new { db = bucket, org });
+            await SendAsync(client, HttpMethod.Post, "/api/v3/configure/database", body);
+            await SendAsync(client, HttpMethod.Delete, $"/api/v3/configure/database?db={Uri.EscapeDataString(bucket)}");
+        }
+
+        private async Task ConfigureTableAsync(HttpClient client, string bucket)
+        {
+            var body = JsonSerializer.Serialize(new
+            {
+                db = bucket,
+                table = "test_table",
+                columns = new[]
+                {
+                    new { name = "_time", type = "timestamp" },
+                    new { name = "value", type = "double" }
+                }
+            });
+            await SendAsync(client, HttpMethod.Post, "/api/v3/configure/table", body);
+            await SendAsync(client, HttpMethod.Delete, $"/api/v3/configure/table?db={Uri.EscapeDataString(bucket)}&table=test_table");
+        }
+
+        private async Task InstallPackagesAsync(HttpClient client)
+        {
+            var body = JsonSerializer.Serialize(new { packages = new[] { "influxdb3-python" } });
+            await SendAsync(client, HttpMethod.Post, "/api/v3/configure/plugin_environment/install_packages", body);
+        }
+
+        private async Task ListTokensAsync(HttpClient client)
+        {
+            var body = JsonSerializer.Serialize(new { db = "_internal", query = "SELECT id, name, permissions FROM system.tokens", format = "json" });
+            await SendAsync(client, HttpMethod.Post, "/api/v3/query/sql", body);
+        }
+
+        private async Task SendAsync(HttpClient client, HttpMethod method, string path, string? body = null, string media = "application/json")
+        {
+            HttpResponseMessage res;
+            if (method == HttpMethod.Get)
+            {
+                res = await client.GetAsync(path);
+            }
+            else
+            {
+                var req = new HttpRequestMessage(method, path);
+                if (body != null)
+                {
+                    req.Content = new StringContent(body, Encoding.UTF8, media);
+                }
+                res = await client.SendAsync(req);
+            }
+
+            _logger.LogInformation("[Test] {Method} {Path} -> {Status}", method.Method, path, res.StatusCode);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- replace Program.cs with minimal host that registers Swagger and Influx services
- implement DataPointController using constructor-injected `InfluxDBClient`
- add `DataPointDto` model
- add extension methods for registering InfluxDB SDK and raw client
- break out raw HTTP test helpers into `InfluxRawTestService`
- update infrastructure project references

## Testing
- `dotnet restore LEMP.sln`
- `dotnet build LEMP.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_687fa268d4d4832daabfd4aab3f97832