### PR TITLE
Implement control evaluation models and controller

### DIFF
--- a/LEMP.Api/Controllers/ControlController.cs
+++ b/LEMP.Api/Controllers/ControlController.cs
@@ -1,25 +1,105 @@
 using LEMP.Api.Models;
+using LEMP.Application.Control;
+using LEMP.Domain.Control;
 using Microsoft.AspNetCore.Mvc;
 
-namespace LEMP.Api.Controllers
-{
-    [ApiController]
-    [Route("api/control")]
-    public class ControlController : ControllerBase
-    {
-        // POST /api/control/inverter
-        [HttpPost("inverter")]
-        public IActionResult ControlInverter([FromBody] InverterControlDto dto)
-        {
-            // In a real implementation commands would be queued/executed
-            return Ok(new { status = "accepted" });
-        }
+namespace LEMP.Api.Controllers;
 
-        // POST /api/control/digital
-        [HttpPost("digital")]
-        public IActionResult SetDeviceState([FromBody] DigitalControlDto dto)
+[ApiController]
+[Route("api/control")]
+public class ControlController : ControllerBase
+{
+    private readonly ControlEngine _engine;
+
+    public ControlController(ControlEngine engine)
+    {
+        _engine = engine;
+    }
+
+    // POST /api/control/evaluate
+    [HttpPost("evaluate")]
+    public ActionResult Evaluate([FromBody] ControlEvaluateRequest request)
+    {
+        var state = _engine.EvaluateState(request.Battery, request.Inverter, request.SmartMeter);
+        return Ok(new { state });
+    }
+
+    // GET /api/control/config
+    [HttpGet("config")]
+    public IActionResult GetConfig()
+    {
+        return Ok(new
         {
-            return Ok(new { status = "accepted" });
-        }
+            _engine.ShutoffThresholdSOC,
+            _engine.RestartThresholdSOC
+        });
+    }
+
+    // POST /api/control/reset
+    [HttpPost("reset")]
+    public IActionResult Reset()
+    {
+        _engine.RequestBatteryReset();
+        return Ok(new { status = "reset_requested" });
+    }
+
+    // POST /api/control/apply
+    [HttpPost("apply")]
+    public IActionResult Apply()
+    {
+        _engine.ApplyLastState();
+        return Ok(new { status = "applied" });
+    }
+
+    // GET /api/control/state
+    [HttpGet("state")]
+    public IActionResult GetState()
+    {
+        var (state, time) = _engine.GetLastState();
+        return Ok(new { state, time });
+    }
+
+    // POST /api/control/override
+    [HttpPost("override")]
+    public IActionResult SetOverride([FromQuery] ControlState state)
+    {
+        _engine.SetOverride(state);
+        return Ok(new { status = "override_set", state });
+    }
+
+    // DELETE /api/control/override
+    [HttpDelete("override")]
+    public IActionResult ClearOverride()
+    {
+        _engine.ClearOverride();
+        return Ok(new { status = "override_cleared" });
+    }
+
+    // GET /api/control/logs
+    [HttpGet("logs")]
+    public IActionResult GetLogs() => Ok(_engine.GetLogs());
+
+    // GET /api/control/metrics
+    [HttpGet("metrics")]
+    public IActionResult GetMetrics()
+    {
+        return Ok(new
+        {
+            battery = _engine.LastBattery,
+            inverter = _engine.LastInverter,
+            smartMeter = _engine.LastSmartMeter
+        });
+    }
+
+    // GET /api/control/health
+    [HttpGet("health")]
+    public IActionResult Health() => Ok("ok");
+
+    // POST /api/control/simulate
+    [HttpPost("simulate")]
+    public ActionResult Simulate([FromBody] ControlEvaluateRequest request)
+    {
+        var state = _engine.EvaluateState(request.Battery, request.Inverter, request.SmartMeter);
+        return Ok(new { state });
     }
 }

--- a/LEMP.Api/LEMP.Api.csproj
+++ b/LEMP.Api/LEMP.Api.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <ProjectReference Include="..\LEMP.Application\LEMP.Application.csproj" />
     <ProjectReference Include="..\LEMP.Infrastructure\LEMP.Infrastructure.csproj" />
+    <ProjectReference Include="..\LEMP.Domain\LEMP.Domain.csproj" />
   </ItemGroup>
 
 </Project>

--- a/LEMP.Api/Models/ControlEvaluateRequest.cs
+++ b/LEMP.Api/Models/ControlEvaluateRequest.cs
@@ -1,0 +1,13 @@
+using LEMP.Domain.Control;
+
+namespace LEMP.Api.Models;
+
+/// <summary>
+/// Request payload containing all measurement states for evaluation.
+/// </summary>
+public class ControlEvaluateRequest
+{
+    public required BatteryState Battery { get; set; }
+    public required InverterState Inverter { get; set; }
+    public required SmartMeterState SmartMeter { get; set; }
+}

--- a/LEMP.Api/Program.cs
+++ b/LEMP.Api/Program.cs
@@ -16,6 +16,7 @@ builder.Services.AddInfluxRawHttpClient(builder.Configuration);
 
 // Service hosting raw HTTP tests if needed.
 builder.Services.AddTransient<InfluxRawTestService>();
+builder.Services.AddSingleton<LEMP.Application.Control.ControlEngine>();
 
 var app = builder.Build();
 

--- a/LEMP.Application/Control/ControlEngine.cs
+++ b/LEMP.Application/Control/ControlEngine.cs
@@ -1,0 +1,84 @@
+using LEMP.Domain.Control;
+
+namespace LEMP.Application.Control;
+
+/// <summary>
+/// Simple evaluation engine for determining the system control state.
+/// </summary>
+public class ControlEngine
+{
+    private ControlState _lastState = ControlState.Idle;
+    private DateTime _lastStateTime = DateTime.MinValue;
+    private ControlState? _manualOverride;
+
+    public BatteryState? LastBattery { get; private set; }
+    public InverterState? LastInverter { get; private set; }
+    public SmartMeterState? LastSmartMeter { get; private set; }
+
+    private readonly List<string> _logs = new();
+
+    public double ShutoffThresholdSOC { get; set; } = 5.0;
+    public double RestartThresholdSOC { get; set; } = 10.0;
+
+    /// <summary>
+    /// Evaluates the system state based on incoming measurements.
+    /// </summary>
+    public ControlState EvaluateState(BatteryState battery, InverterState inverter, SmartMeterState meter)
+    {
+        LastBattery = battery;
+        LastInverter = inverter;
+        LastSmartMeter = meter;
+
+        var state = _manualOverride ?? ComputeState(battery, inverter, meter);
+        _lastState = state;
+        _lastStateTime = DateTime.UtcNow;
+        _logs.Add($"State evaluated: {state} at {_lastStateTime:O}");
+        return state;
+    }
+
+    private ControlState ComputeState(BatteryState b, InverterState i, SmartMeterState m)
+    {
+        if ((b.BatteryAlarms != null && b.BatteryAlarms.Length > 0) ||
+            (i.InverterAlarmCodes != null && i.InverterAlarmCodes.Length > 0))
+        {
+            return ControlState.Error;
+        }
+
+        if (b.BatterySOC < ShutoffThresholdSOC)
+        {
+            return ControlState.Error;
+        }
+
+        if (b.BatterySOC < 20 && b.BatteryChargeAllowed && b.BatteryCanCharge)
+        {
+            return ControlState.Charge;
+        }
+
+        if (b.BatterySOC > 80 && b.BatteryDischargeAllowed && b.BatteryCanDischarge)
+        {
+            return ControlState.Discharge;
+        }
+
+        return ControlState.Idle;
+    }
+
+    public (ControlState State, DateTime Time) GetLastState() => (_lastState, _lastStateTime);
+
+    public void RequestBatteryReset() => _logs.Add("Battery reset requested");
+
+    public void ApplyLastState() => _logs.Add($"Applied state: {_lastState}");
+
+    public void SetOverride(ControlState state)
+    {
+        _manualOverride = state;
+        _logs.Add($"Manual override set: {state}");
+    }
+
+    public void ClearOverride()
+    {
+        _manualOverride = null;
+        _logs.Add("Manual override cleared");
+    }
+
+    public IReadOnlyList<string> GetLogs() => _logs.AsReadOnly();
+}

--- a/LEMP.Domain/Control/BatteryState.cs
+++ b/LEMP.Domain/Control/BatteryState.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace LEMP.Domain.Control;
+
+/// <summary>
+/// Represents current Battery Management System information.
+/// </summary>
+public class BatteryState
+{
+    public double BatteryNominalCapacityAh { get; set; }
+    public double BatteryUsableCapacityPercent { get; set; }
+    public double BatterySOC { get; set; }
+    public double BatteryDOD { get; set; }
+    public double BatteryVoltage { get; set; }
+    public double BatteryCurrent { get; set; }
+    public double BatteryPowerW { get; set; }
+    public double BatteryTemperatureMax { get; set; }
+    public double BatteryTemperatureMin { get; set; }
+    public double[]? BatteryCellVoltages { get; set; }
+    public bool BatteryBalanceActive { get; set; }
+    public bool BatteryChargeAllowed { get; set; }
+    public bool BatteryDischargeAllowed { get; set; }
+    public string[]? BatteryAlarms { get; set; }
+    public BatteryStatus BatteryStatus { get; set; }
+    public bool BatteryCanCharge { get; set; }
+    public bool BatteryCanDischarge { get; set; }
+    public double BatteryShutoffThresholdSoc { get; set; }
+    public double BatteryRestartThresholdSoc { get; set; }
+    public double BatteryChargePowerLimitW { get; set; }
+    public double BatteryDischargePowerLimitW { get; set; }
+    public bool BatteryCommAlive { get; set; }
+    public bool BatteryIsCalibrated { get; set; }
+    public double BatteryAllowedChargeVoltageMax { get; set; }
+    public double BatteryAllowedDischargeVoltageMin { get; set; }
+    public bool BatteryResetRequest { get; set; }
+    public bool BatteryForceStop { get; set; }
+}

--- a/LEMP.Domain/Control/Enums.cs
+++ b/LEMP.Domain/Control/Enums.cs
@@ -1,0 +1,30 @@
+namespace LEMP.Domain.Control;
+
+// Battery overall status values
+public enum BatteryStatus
+{
+    Unknown,
+    Normal,
+    Error,
+    Balancing,
+    Shutdown
+}
+
+// Inverter operating modes
+public enum InverterMode
+{
+    Unknown,
+    GridTied,
+    OffGrid,
+    Charge,
+    Standby
+}
+
+// Resulting control state from the control engine
+public enum ControlState
+{
+    Idle,
+    Charge,
+    Discharge,
+    Error
+}

--- a/LEMP.Domain/Control/InverterState.cs
+++ b/LEMP.Domain/Control/InverterState.cs
@@ -1,0 +1,21 @@
+namespace LEMP.Domain.Control;
+
+/// <summary>
+/// Represents inverter telemetry and limits.
+/// </summary>
+public class InverterState
+{
+    public double InverterOutputPowerW { get; set; }
+    public double InverterInputPowerW { get; set; }
+    public InverterMode InverterMode { get; set; }
+    public string? InverterStatus { get; set; }
+    public bool InverterGridConnected { get; set; }
+    public double InverterBatteryPowerW { get; set; }
+    public double InverterPVPowerW { get; set; }
+    public double InverterAllowedChargePowerW { get; set; }
+    public double InverterAllowedDischargePowerW { get; set; }
+    public double InverterSetPowerW { get; set; }
+    public double InverterReactivePowerVar { get; set; }
+    public double InverterFrequencyHz { get; set; }
+    public string[]? InverterAlarmCodes { get; set; }
+}

--- a/LEMP.Domain/Control/SmartMeterState.cs
+++ b/LEMP.Domain/Control/SmartMeterState.cs
@@ -1,0 +1,24 @@
+namespace LEMP.Domain.Control;
+
+/// <summary>
+/// Represents smart meter measurements.
+/// </summary>
+public class SmartMeterState
+{
+    public double GridImportPowerW { get; set; }
+    public double GridExportPowerW { get; set; }
+    public double GridVoltageL1 { get; set; }
+    public double GridVoltageL2 { get; set; }
+    public double GridVoltageL3 { get; set; }
+    public double GridCurrentL1 { get; set; }
+    public double GridCurrentL2 { get; set; }
+    public double GridCurrentL3 { get; set; }
+    public double GridActivePowerTotal { get; set; }
+    public double GridReactivePowerTotal { get; set; }
+    public double GridApparentPowerTotal { get; set; }
+    public double GridFrequencyHz { get; set; }
+    public double GridEnergyImportedWh { get; set; }
+    public double GridEnergyExportedWh { get; set; }
+    public double PowerFactor { get; set; }
+    public bool SmartMeterAlive { get; set; }
+}


### PR DESCRIPTION
## Summary
- implement domain models for battery, inverter and smart meter states
- add enums and control engine service
- expose evaluation API via ControlController
- wire ControlEngine into DI and reference Domain project

## Testing
- `dotnet build LEMP.sln -v minimal`
- `dotnet test LEMP.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_688b6dee0d38832d8f3d9df529d4b405