### PR TITLE
feat: add request audit middleware and admin audit query

### DIFF
--- a/LEMP.Api/Controllers/AuditLogController.cs
+++ b/LEMP.Api/Controllers/AuditLogController.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using InfluxDB3.Client;
+using InfluxDB3.Client.Exceptions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LEMP.Api.Controllers
+{
+    /// <summary>
+    /// API endpoint for querying audit logs from InfluxDB.
+    /// Accessible only to users with the Admin role.
+    /// </summary>
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize(Roles = "Admin")]
+    public class AuditLogController : ControllerBase
+    {
+        private readonly InfluxDBClient _client;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="AuditLogController"/>.
+        /// </summary>
+        /// <param name="client">InfluxDB client used for querying audit logs.</param>
+        public AuditLogController(InfluxDBClient client)
+        {
+            _client = client;
+        }
+
+        /// <summary>
+        /// Returns the latest audit log entries.
+        /// </summary>
+        /// <param name="limit">Maximum number of entries to return.</param>
+        /// <returns>List of audit log rows.</returns>
+        [HttpGet]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        public async Task<IActionResult> Get([FromQuery] int limit = 100)
+        {
+            var sql = $"select * from auditlog order by time desc limit {limit}";
+            var rows = new List<object?[]>();
+
+            try
+            {
+                await foreach (var row in _client.Query(query: sql))
+                {
+                    rows.Add(row);
+                }
+            }
+            catch (InfluxDBApiException ex)
+            {
+                return StatusCode((int)ex.StatusCode, ex.Message);
+            }
+
+            return Ok(rows);
+        }
+    }
+}
+

--- a/LEMP.Api/Middleware/RequestAuditMiddleware.cs
+++ b/LEMP.Api/Middleware/RequestAuditMiddleware.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using System.Security.Claims;
+
+namespace LEMP.Api.Middleware
+{
+    /// <summary>
+    /// Middleware responsible for auditing HTTP requests and writing audit logs to InfluxDB using line protocol.
+    /// </summary>
+    public class RequestAuditMiddleware
+    {
+        private const string InfluxWriteUrl = "http://localhost:8181/api/v3/write_lp?db=audit&precision=nanosecond";
+
+        private readonly RequestDelegate _next;
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly ILogger<RequestAuditMiddleware> _logger;
+
+        public RequestAuditMiddleware(RequestDelegate next, IHttpClientFactory httpClientFactory, ILogger<RequestAuditMiddleware> logger)
+        {
+            _next = next;
+            _httpClientFactory = httpClientFactory;
+            _logger = logger;
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            var sw = Stopwatch.StartNew();
+            try
+            {
+                await _next(context);
+            }
+            finally
+            {
+                sw.Stop();
+                await WriteAuditLogAsync(context, sw.Elapsed.TotalMilliseconds);
+            }
+        }
+
+        private async Task WriteAuditLogAsync(HttpContext context, double durationMs)
+        {
+            var user = context.User?.Identity?.IsAuthenticated == true
+                ? context.User.Identity!.Name ?? "anonymous"
+                : "anonymous";
+
+            var role = context.User?.Identity?.IsAuthenticated == true
+                ? context.User.Claims.FirstOrDefault(c => c.Type == ClaimTypes.Role)?.Value ?? "none"
+                : "none";
+
+            var method = context.Request.Method;
+            var path = context.Request.Path.HasValue ? context.Request.Path.Value! : string.Empty;
+            var status = context.Response.StatusCode;
+            var ip = context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+            var id = Guid.NewGuid().ToString("N");
+
+            var timestamp = (DateTime.UtcNow - DateTime.UnixEpoch).Ticks * 100; // nanoseconds
+
+            var line = BuildLineProtocol(id, user, role, method, path, status, durationMs, ip, timestamp);
+
+            var client = _httpClientFactory.CreateClient();
+            using var content = new StringContent(line, Encoding.UTF8);
+            try
+            {
+                using var response = await client.PostAsync(InfluxWriteUrl, content);
+                response.EnsureSuccessStatusCode();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to send audit log to InfluxDB.");
+            }
+        }
+
+        private static string BuildLineProtocol(string id, string user, string role, string method, string path, int status, double durationMs, string ip, long timestamp)
+        {
+            var sb = new StringBuilder();
+            sb.Append("auditlog");
+            sb.Append(",user=").Append(EscapeTag(user));
+            sb.Append(",role=").Append(EscapeTag(role));
+            sb.Append(",method=").Append(EscapeTag(method));
+            sb.Append(",path=").Append(EscapeTag(path));
+            sb.Append(",ip=").Append(EscapeTag(ip));
+            sb.Append(' ');
+            sb.Append("id=\"").Append(EscapeField(id)).Append('\"');
+            sb.Append(",status=").Append(status).Append('i');
+            sb.Append(",durationMs=").Append(durationMs.ToString(CultureInfo.InvariantCulture));
+            sb.Append(' ');
+            sb.Append(timestamp.ToString(CultureInfo.InvariantCulture));
+            return sb.ToString();
+        }
+
+        private static string EscapeTag(string value) => value
+            .Replace("\\", "\\\\")
+            .Replace(",", "\\,")
+            .Replace(" ", "\\ ")
+            .Replace("=", "\\=");
+
+        private static string EscapeField(string value) => value
+            .Replace("\\", "\\\\")
+            .Replace("\"", "\\\"");
+    }
+}
+

--- a/LEMP.Api/Program.cs
+++ b/LEMP.Api/Program.cs
@@ -1,5 +1,6 @@
 using LEMP.Infrastructure.Extensions;
 using LEMP.Infrastructure.Services;
+using LEMP.Api.Middleware;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
@@ -85,6 +86,8 @@ if (app.Environment.IsDevelopment())
 app.UseHttpsRedirection();
 app.UseAuthentication(); // Fontos: Authentication mindig Authorization előtt
 app.UseAuthorization();
+
+app.UseMiddleware<RequestAuditMiddleware>();
 
 app.MapControllers();
 


### PR DESCRIPTION
## Summary
- add RequestAuditMiddleware registration for audit logging
- add AuditLogController that lets Admins query audit log entries from InfluxDB

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6893586f3d18832d8253cd2a180856a0