### PR TITLE
Enable Serilog logging with rolling files

### DIFF
--- a/LEMP.Api/Controllers/AuditLogController.cs
+++ b/LEMP.Api/Controllers/AuditLogController.cs
@@ -27,6 +27,8 @@ public class AuditLogController : ControllerBase
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> Get([FromQuery] int limit = 100)
     {
+        _logger.LogInformation("Fetching latest {Count} audit logs", limit);
+
         var sql = $"SELECT * FROM auditlog ORDER BY time DESC LIMIT {limit}";
         var rows = new List<object?[]>();
 
@@ -48,6 +50,7 @@ public class AuditLogController : ControllerBase
             return StatusCode(StatusCodes.Status500InternalServerError, ex.ToString());
         }
 
+        _logger.LogInformation("Returning {Count} audit log entries", rows.Count);
         return Ok(rows);
     }
 }

--- a/LEMP.Api/Controllers/SmartMeterController.cs
+++ b/LEMP.Api/Controllers/SmartMeterController.cs
@@ -6,6 +6,7 @@ using InfluxDB3.Client;
 using LEMP.Api.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace LEMP.Api.Controllers
 {
@@ -14,12 +15,13 @@ namespace LEMP.Api.Controllers
     public class SmartMeterController : ControllerBase
     {
         private readonly InfluxDBClient _client;
+        private readonly ILogger<SmartMeterController> _logger;
 
-        public SmartMeterController(InfluxDBClient client)
+        public SmartMeterController(InfluxDBClient client, ILogger<SmartMeterController> logger)
         {
             _client = client;
+            _logger = logger;
         }
-
 
         [HttpGet]
         [ProducesResponseType(StatusCodes.Status200OK)]
@@ -27,6 +29,8 @@ namespace LEMP.Api.Controllers
         {
             if (limit <= 0)
                 limit = 1;
+
+            _logger.LogInformation("Fetching {Limit} smart meter readings", limit);
 
             var sql = $"""
                 SELECT
@@ -77,12 +81,14 @@ namespace LEMP.Api.Controllers
                 }
                 catch (Exception ex)
                 {
-                    // elnyeljük az esetleges konverziós hibát, logolhatod is ha kell
+                    _logger.LogWarning(ex, "Failed to parse smart meter row");
                     continue;
                 }
             }
 
+            _logger.LogInformation("Returning {Count} smart meter readings", result.Count);
             return Ok(result);
         }
     }
 }
+

--- a/LEMP.Api/LEMP.Api.csproj
+++ b/LEMP.Api/LEMP.Api.csproj
@@ -7,6 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.3" />
   </ItemGroup>
 

--- a/LEMP.Api/appsettings.json
+++ b/LEMP.Api/appsettings.json
@@ -2,8 +2,31 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "System.Net.Http.HttpClient": "Warning"
     }
+  },
+  "Serilog": {
+    "Using": [ "Serilog.Sinks.File" ],
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Information",
+        "System.Net.Http.HttpClient": "Warning"
+      }
+    },
+    "Enrich": [ "FromLogContext" ],
+    "WriteTo": [
+      { "Name": "Console" },
+      {
+        "Name": "File",
+        "Args": {
+          "path": "Logs/log-.log",
+          "rollingInterval": "Day",
+          "outputTemplate": "{Timestamp:yyyy-MM-dd HH:mm:ss} [{Level:u3}] {SourceContext} {Message:lj}{NewLine}{Exception}"
+        }
+      }
+    ]
   },
   "InfluxDB": {
     "Host": "localhost",

--- a/LEMP.Test/DataPointControllerTests.cs
+++ b/LEMP.Test/DataPointControllerTests.cs
@@ -2,6 +2,7 @@ using System.Threading.Tasks;
 using LEMP.Api.Controllers;
 using LEMP.Api.Models;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
 
 namespace LEMP.Test;
@@ -11,7 +12,7 @@ public class DataPointControllerTests
     [Test]
     public async Task Get_ReturnsBadRequest_WhenMeasurementMissing()
     {
-        var controller = new DataPointController(null!);
+        var controller = new DataPointController(null!, NullLogger<DataPointController>.Instance);
 
         var result = await controller.Get(measurement: null!);
 
@@ -21,7 +22,7 @@ public class DataPointControllerTests
     [Test]
     public async Task Post_ReturnsBadRequest_WhenMeasurementMissing()
     {
-        var controller = new DataPointController(null!);
+        var controller = new DataPointController(null!, NullLogger<DataPointController>.Instance);
         var dto = new DataPointDto { Measurement = "" };
 
         var result = await controller.Post(dto);


### PR DESCRIPTION
## Summary
- integrate Serilog using configuration-driven setup
- write logs to console and daily rolling file with category and level
- add Serilog packages and middleware for request logging
- enrich request logs with user context and add custom ILogger messages across controllers

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6895e950634c832d98dcfa450e397add