### PR TITLE
Make runtime settings configurable

### DIFF
--- a/LEMP.Api/Program.cs
+++ b/LEMP.Api/Program.cs
@@ -14,9 +14,12 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Host.UseSerilog((context, services, configuration) =>
     configuration.ReadFrom.Configuration(context.Configuration));
 
-var jwtKey = builder.Configuration["Jwt:Key"] ?? "NagyonTitkosKulcsValtoztasdMeg123";
-var jwtIssuer = builder.Configuration["Jwt:Issuer"] ?? "LEMP.API";
-var jwtAudience = builder.Configuration["Jwt:Audience"] ?? "KEP.Client";
+var jwtKey = builder.Configuration["Jwt:Key"]
+             ?? throw new InvalidOperationException("Jwt:Key is not configured");
+var jwtIssuer = builder.Configuration["Jwt:Issuer"]
+                ?? throw new InvalidOperationException("Jwt:Issuer is not configured");
+var jwtAudience = builder.Configuration["Jwt:Audience"]
+                 ?? throw new InvalidOperationException("Jwt:Audience is not configured");
 
 JwtSecurityTokenHandler.DefaultInboundClaimTypeMap.Clear();
 
@@ -70,10 +73,6 @@ builder.Services.AddSwaggerGen(c =>
 
 builder.Services.AddInfluxDbClient(builder.Configuration);
 builder.Services.AddInfluxRawHttpClient(builder.Configuration);
-builder.Services.AddHttpClient("Influx", client =>
-{
-    client.BaseAddress = new Uri("http://localhost:8181");
-});
 
 builder.Services.AddTransient<InfluxRawTestService>();
 builder.Services.AddHostedService<SmartMeterInfluxForwarder>();

--- a/LEMP.Api/appsettings.Development.json
+++ b/LEMP.Api/appsettings.Development.json
@@ -14,7 +14,8 @@
     "NodeId": "node0"
   },
   "SmartMeter": {
-    "SerialPort": "COM9"
+    "SerialPort": "COM9",
+    "PollingIntervalSeconds": 5
   },
   "Jwt": {
     "Key": "Tru3lyRand0mS3cureKeyForJWTxxXY16",

--- a/LEMP.Api/appsettings.json
+++ b/LEMP.Api/appsettings.json
@@ -37,7 +37,8 @@
     "NodeId": "node0"
   },
   "SmartMeter": {
-    "SerialPort": "COM9"
+    "SerialPort": "COM9",
+    "PollingIntervalSeconds": 5
   },
   "Jwt": {
     "Key": "Tru3lyRand0mS3cureKeyForJWTxxXY16",


### PR DESCRIPTION
## Summary
- remove hardcoded defaults for JWT validation and Influx client
- add polling interval and serial port configuration for smart meter forwarder
- ensure Influx and JWT settings are supplied via appsettings

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689c6b6e38e8832dba0eafaccbc08560