### PR TITLE
Include scale and unit details in inverter register logs

### DIFF
--- a/LEMP.Test/InverterModbusAdapterTests.cs
+++ b/LEMP.Test/InverterModbusAdapterTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.IO.Ports;
 using System.Linq;
@@ -30,6 +31,14 @@ public class InverterModbusAdapterTests
         Assert.That(snapshot.InverterAlive, Is.True, "Minden Modbus lekérdezésnek sikeresnek kell lennie.");
         Assert.That(snapshot.Groups, Is.Not.Empty, "A lekérdezett csoportok listája nem lehet üres.");
 
+        var definitionsByGroup = groups.ToDictionary(
+            kvp => kvp.Key,
+            kvp => kvp.Value
+                .Where(def => !string.IsNullOrWhiteSpace(def.Name))
+                .GroupBy(def => def.Name, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase),
+            StringComparer.OrdinalIgnoreCase);
+
         var expectedNamesByGroup = groups.ToDictionary(
             kvp => kvp.Key,
             kvp => kvp.Value
@@ -54,6 +63,37 @@ public class InverterModbusAdapterTests
         var totalExpected = expectedNamesByGroup.Values.Sum(v => v.Count);
         var totalActual = snapshot.Groups.Values.Sum(v => v.Count);
         Assert.That(totalActual, Is.EqualTo(totalExpected), "Minden aktív regiszterértéket vissza kell adni.");
+
+        TestContext.WriteLine("Olvasott inverter Modbus értékek:");
+
+        foreach (var group in snapshot.Groups
+                     .OrderBy(g => g.Key, StringComparer.OrdinalIgnoreCase))
+        {
+            TestContext.WriteLine($"  Csoport: {group.Key}");
+
+            foreach (var register in group.Value
+                         .OrderBy(r => r.Key, StringComparer.OrdinalIgnoreCase))
+            {
+                if (definitionsByGroup.TryGetValue(group.Key, out var definitions) &&
+                    definitions.TryGetValue(register.Key, out var definition))
+                {
+                    var formattedValue = register.Value.ToString(CultureInfo.InvariantCulture);
+                    var unit = definition.Unit;
+                    var prefix = string.IsNullOrWhiteSpace(unit) || unit.Equals("null", StringComparison.OrdinalIgnoreCase)
+                        ? string.Empty
+                        : $" {unit}";
+                    var scaleSuffix = Math.Abs(definition.Scale - 1d) > double.Epsilon
+                        ? $" (scale: {definition.Scale.ToString("G15", CultureInfo.InvariantCulture)})"
+                        : string.Empty;
+
+                    TestContext.WriteLine($"    {register.Key}: {formattedValue}{prefix}{scaleSuffix}");
+                }
+                else
+                {
+                    TestContext.WriteLine($"    {register.Key}: {register.Value.ToString(CultureInfo.InvariantCulture)}");
+                }
+            }
+        }
 
         var planField = typeof(InverterModbusAdapter).GetField("_plan", BindingFlags.NonPublic | BindingFlags.Instance);
         Assert.That(planField, Is.Not.Null, "Nem sikerült elérni az olvasási tervet reflexióval.");


### PR DESCRIPTION
## Summary
- look up register metadata so the Deye snapshot test can format values consistently
- append the configured unit and scale information when logging inverter Modbus register values during the test output

## Testing
- dotnet test LEMP.sln --filter DeyeMap_AllActiveRegistersCanBeRead --logger "console;verbosity=normal"


------
https://chatgpt.com/codex/tasks/task_e_68d65f4c8f2c832d8c0b46cd713bda0c