### PR TITLE
Handle inverter register types explicitly

### DIFF
--- a/LEMP.Test/DeyeModbusRegisterDefinitionTests.cs
+++ b/LEMP.Test/DeyeModbusRegisterDefinitionTests.cs
@@ -71,34 +71,17 @@ public class DeyeModbusRegisterDefinitionTests
     }
 
     [Test]
-    public void TryConvert_ReadsFloat()
+    public void TryConvert_ReturnsFalseForUnexpectedLength()
     {
-        var definition = CreateDefinition("float", length: 2, scale: 1);
+        var definition = CreateDefinition("uint16", length: 2, scale: 1); // uint16 should only use 1 register
         Span<byte> raw = stackalloc byte[4];
-        var bits = BitConverter.SingleToInt32Bits(123.456f);
-        BinaryPrimitives.WriteInt32BigEndian(raw, bits);
 
         var success = definition.TryConvert(raw, out var value);
 
         Assert.Multiple(() =>
         {
-            Assert.That(success, Is.True);
-            Assert.That(value, Is.EqualTo(123.456f).Within(1e-6));
-        });
-    }
-
-    [Test]
-    public void TryConvert_ReadsBool()
-    {
-        var definition = CreateDefinition("bool", length: 1, scale: 1);
-        Span<byte> raw = stackalloc byte[] { 0x00, 0x01 };
-
-        var success = definition.TryConvert(raw, out var value);
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(success, Is.True);
-            Assert.That(value, Is.EqualTo(1d));
+            Assert.That(success, Is.False);
+            Assert.That(value, Is.EqualTo(0d));
         });
     }
 
@@ -115,6 +98,12 @@ public class DeyeModbusRegisterDefinitionTests
             Assert.That(success, Is.False);
             Assert.That(value, Is.EqualTo(0d));
         });
+    }
+
+    [Test]
+    public void Constructor_ThrowsForUnsupportedType()
+    {
+        Assert.That(() => CreateDefinition("float", length: 2, scale: 1), Throws.ArgumentException);
     }
 
     private static DeyeModbusRegisterDefinition CreateDefinition(string dataType, ushort length, double scale) =>

--- a/LEMP.Test/InverterModbusAdapterTests.cs
+++ b/LEMP.Test/InverterModbusAdapterTests.cs
@@ -151,9 +151,8 @@ public class InverterModbusAdapterTests
 
         return normalizedType switch
         {
-            "bool" or "boolean" => Math.Abs(value) > 0.5 ? "true" : "false",
-            "single" or "float" or "float32" => ((float)value).ToString("G9", CultureInfo.InvariantCulture),
-            "double" or "float64" => value.ToString("G17", CultureInfo.InvariantCulture),
+            "int16" or "int32" => Math.Round(value, MidpointRounding.AwayFromZero)
+                .ToString(CultureInfo.InvariantCulture),
             _ => value.ToString("G15", CultureInfo.InvariantCulture)
         };
     }
@@ -171,9 +170,6 @@ public class InverterModbusAdapterTests
             "uint16" => ((ushort)Math.Round(baseValue, MidpointRounding.AwayFromZero)).ToString(CultureInfo.InvariantCulture),
             "int32" => ((int)Math.Round(baseValue, MidpointRounding.AwayFromZero)).ToString(CultureInfo.InvariantCulture),
             "uint32" => ((uint)Math.Round(baseValue, MidpointRounding.AwayFromZero)).ToString(CultureInfo.InvariantCulture),
-            "single" or "float" or "float32" => ((float)baseValue).ToString("G9", CultureInfo.InvariantCulture),
-            "double" or "float64" => baseValue.ToString("G17", CultureInfo.InvariantCulture),
-            "bool" or "boolean" => Math.Abs(baseValue) > 0.5 ? "true" : "false",
             _ => baseValue.ToString("G15", CultureInfo.InvariantCulture)
         };
 
@@ -232,27 +228,6 @@ public class InverterModbusAdapterTests
                     }
 
                     BinaryPrimitives.WriteInt32BigEndian(destination, checked((int)Math.Round(baseValue, MidpointRounding.AwayFromZero)));
-                    return true;
-                case "single" or "float" or "float32":
-                    if (destination.Length < 4)
-                    {
-                        return false;
-                    }
-
-                    var floatBits = BitConverter.SingleToInt32Bits((float)baseValue);
-                    BinaryPrimitives.WriteInt32BigEndian(destination, floatBits);
-                    return true;
-                case "double" or "float64":
-                    if (destination.Length < 8)
-                    {
-                        return false;
-                    }
-
-                    var doubleBits = BitConverter.DoubleToInt64Bits(baseValue);
-                    BinaryPrimitives.WriteInt64BigEndian(destination, doubleBits);
-                    return true;
-                case "bool" or "boolean":
-                    destination[destination.Length - 1] = Math.Abs(baseValue) > 0.5 ? (byte)1 : (byte)0;
                     return true;
                 default:
                     return false;


### PR DESCRIPTION
## Summary
- parse inverter register definitions into explicit data types before scaling values
- ignore unsupported data types when loading the Modbus map
- align inverter unit tests with the supported register types and formatting helpers

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68d67b936960832d8ebfb02209942b9b