### PR TITLE
Capture inverter register metadata and forward raw values

### DIFF
--- a/LEMP.Domain/Inverter/InverterRegisterValue.cs
+++ b/LEMP.Domain/Inverter/InverterRegisterValue.cs
@@ -1,0 +1,8 @@
+namespace LEMP.Domain.Inverter;
+
+public sealed record InverterRegisterValue(
+    double Value,
+    double RawValue,
+    string DataType,
+    double Scale,
+    string? Unit);

--- a/LEMP.Domain/Inverter/InverterSnapshot.cs
+++ b/LEMP.Domain/Inverter/InverterSnapshot.cs
@@ -6,6 +6,6 @@ public class InverterSnapshot
 
     public DateTimeOffset Timestamp { get; set; }
 
-    public Dictionary<string, Dictionary<string, double>> Groups { get; } =
+    public Dictionary<string, Dictionary<string, InverterRegisterValue>> Groups { get; } =
         new(StringComparer.OrdinalIgnoreCase);
 }

--- a/LEMP.Test/InverterModbusAdapterTests.cs
+++ b/LEMP.Test/InverterModbusAdapterTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Reflection;
 using LEMP.Application.Inverter;
 using LEMP.Application.Modbus;
+using LEMP.Domain.Inverter;
 using NUnit.Framework;
 
 namespace LEMP.Test;
@@ -102,7 +103,7 @@ public class InverterModbusAdapterTests
                 }
                 else
                 {
-                    TestContext.WriteLine($"    {register.Key}: {register.Value.ToString(CultureInfo.InvariantCulture)}");
+                    TestContext.WriteLine($"    {register.Key}: {register.Value.Value.ToString(CultureInfo.InvariantCulture)}");
                 }
 
             }
@@ -268,22 +269,21 @@ public class InverterModbusAdapterTests
         }
     }
 
-    private static string FormatScaledValue(double value, DeyeModbusRegisterDefinition definition)
+    private static string FormatScaledValue(InverterRegisterValue register, DeyeModbusRegisterDefinition definition)
     {
         var normalizedType = definition.DataType?.Trim().ToLowerInvariant();
 
         return normalizedType switch
         {
-            "int16" or "int32" => Math.Round(value, MidpointRounding.AwayFromZero)
+            "int16" or "int32" => Math.Round(register.Value, MidpointRounding.AwayFromZero)
                 .ToString(CultureInfo.InvariantCulture),
-            _ => value.ToString("G15", CultureInfo.InvariantCulture)
+            _ => register.Value.ToString("G15", CultureInfo.InvariantCulture)
         };
     }
 
-    private static string FormatRawValue(double scaledValue, DeyeModbusRegisterDefinition definition)
+    private static string FormatRawValue(InverterRegisterValue register, DeyeModbusRegisterDefinition definition)
     {
-        var scale = Math.Abs(definition.Scale) > double.Epsilon ? definition.Scale : 1d;
-        var baseValue = scaledValue / scale;
+        var baseValue = register.RawValue;
         var normalizedType = definition.DataType?.Trim().ToLowerInvariant();
 
         var valueString = normalizedType switch


### PR DESCRIPTION
## Summary
- capture inverter register metadata alongside the scaled readings
- extend the inverter snapshot and line protocol builder to emit both scaled and raw fields
- update inverter unit tests to cover the richer register representation

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68d68e0c5940832da465828be37a6af0