### PR TITLE
Normalize inverter measurement rows

### DIFF
--- a/LEMP.Domain/Inverter/InverterRegisterValue.cs
+++ b/LEMP.Domain/Inverter/InverterRegisterValue.cs
@@ -1,0 +1,8 @@
+namespace LEMP.Domain.Inverter;
+
+public sealed record InverterRegisterValue(
+    double Value,
+    double RawValue,
+    string DataType,
+    double Scale,
+    string? Unit);

--- a/LEMP.Domain/Inverter/InverterSnapshot.cs
+++ b/LEMP.Domain/Inverter/InverterSnapshot.cs
@@ -6,6 +6,6 @@ public class InverterSnapshot
 
     public DateTimeOffset Timestamp { get; set; }
 
-    public Dictionary<string, Dictionary<string, double>> Groups { get; } =
+    public Dictionary<string, Dictionary<string, InverterRegisterValue>> Groups { get; } =
         new(StringComparer.OrdinalIgnoreCase);
 }

--- a/LEMP.Test/InverterInfluxForwarderTests.cs
+++ b/LEMP.Test/InverterInfluxForwarderTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using LEMP.Domain.Inverter;
+using LEMP.Infrastructure.Services;
+using NUnit.Framework;
+
+namespace LEMP.Test;
+
+public class InverterInfluxForwarderTests
+{
+    [Test]
+    public void BuildLineProtocol_WritesRowsPerRegister()
+    {
+        var snapshot = new InverterSnapshot
+        {
+            InverterAlive = true,
+            Timestamp = new DateTimeOffset(2024, 1, 2, 3, 4, 5, TimeSpan.Zero)
+        };
+
+        snapshot.Groups["ac"] = new Dictionary<string, InverterRegisterValue>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["current"] = new InverterRegisterValue(12.34, 123.4, "float", 0.1, "A"),
+            ["voltage"] = new InverterRegisterValue(230.5, 2305, "float", 0.1, "V")
+        };
+
+        var method = typeof(InverterInfluxForwarder).GetMethod(
+            "BuildLineProtocol",
+            BindingFlags.Static | BindingFlags.NonPublic);
+
+        Assert.That(method, Is.Not.Null, "Nem sikerült elérni a BuildLineProtocol metódust reflektív módon.");
+
+        var lines = (List<string>?)method!.Invoke(null, new object[] { "node-1", snapshot });
+
+        Assert.That(lines, Is.Not.Null);
+        Assert.That(lines!, Has.Count.EqualTo(2));
+
+        var timestamp = snapshot.Timestamp.ToUnixTimeMilliseconds() * 1_000_000;
+
+        var expectedCurrent =
+            $"inverter,node=node-1,group=ac,register=current,data_type=float,unit=A value=12.34,raw_value=123.4,scale=0.1 {timestamp}";
+        var expectedVoltage =
+            $"inverter,node=node-1,group=ac,register=voltage,data_type=float,unit=V value=230.5,raw_value=2305,scale=0.1 {timestamp}";
+
+        Assert.That(lines!, Does.Contain(expectedCurrent));
+        Assert.That(lines!, Does.Contain(expectedVoltage));
+    }
+}

--- a/LEMP.Test/InverterModbusAdapterTests.cs
+++ b/LEMP.Test/InverterModbusAdapterTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Reflection;
 using LEMP.Application.Inverter;
 using LEMP.Application.Modbus;
+using LEMP.Domain.Inverter;
 using NUnit.Framework;
 
 namespace LEMP.Test;
@@ -102,7 +103,7 @@ public class InverterModbusAdapterTests
                 }
                 else
                 {
-                    TestContext.WriteLine($"    {register.Key}: {register.Value.ToString(CultureInfo.InvariantCulture)}");
+                    TestContext.WriteLine($"    {register.Key}: {register.Value.Value.ToString(CultureInfo.InvariantCulture)}");
                 }
 
             }
@@ -268,22 +269,21 @@ public class InverterModbusAdapterTests
         }
     }
 
-    private static string FormatScaledValue(double value, DeyeModbusRegisterDefinition definition)
+    private static string FormatScaledValue(InverterRegisterValue register, DeyeModbusRegisterDefinition definition)
     {
         var normalizedType = definition.DataType?.Trim().ToLowerInvariant();
 
         return normalizedType switch
         {
-            "int16" or "int32" => Math.Round(value, MidpointRounding.AwayFromZero)
+            "int16" or "int32" => Math.Round(register.Value, MidpointRounding.AwayFromZero)
                 .ToString(CultureInfo.InvariantCulture),
-            _ => value.ToString("G15", CultureInfo.InvariantCulture)
+            _ => register.Value.ToString("G15", CultureInfo.InvariantCulture)
         };
     }
 
-    private static string FormatRawValue(double scaledValue, DeyeModbusRegisterDefinition definition)
+    private static string FormatRawValue(InverterRegisterValue register, DeyeModbusRegisterDefinition definition)
     {
-        var scale = Math.Abs(definition.Scale) > double.Epsilon ? definition.Scale : 1d;
-        var baseValue = scaledValue / scale;
+        var baseValue = register.RawValue;
         var normalizedType = definition.DataType?.Trim().ToLowerInvariant();
 
         var valueString = normalizedType switch


### PR DESCRIPTION
## Summary
- restructure the inverter forwarder to emit register-level rows suitable for an Influx inverter table
- include metadata tags for register, data type, and unit while writing scaled, raw, and scale fields
- add coverage that exercises the inverter line protocol builder through reflection

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68d68e0c5940832da465828be37a6af0