### PR TITLE
Load smart meter registers from JSON map

### DIFF
--- a/LEMP.Api/appsettings.Development.json
+++ b/LEMP.Api/appsettings.Development.json
@@ -38,7 +38,8 @@
   },
   "SmartMeter": {
     "SerialPort": "COM9",
-    "PollingIntervalSeconds": 5
+    "PollingIntervalSeconds": 5,
+    "MapFile": "Config/smd230smartmeter.json"
   },
   "Inverter": {
     "SerialPort": "COM7",

--- a/LEMP.Api/appsettings.json
+++ b/LEMP.Api/appsettings.json
@@ -38,7 +38,8 @@
   },
   "SmartMeter": {
     "SerialPort": "COM9",
-    "PollingIntervalSeconds": 5
+    "PollingIntervalSeconds": 5,
+    "MapFile": "Config/smd230smartmeter.json"
   },
   "Inverter": {
     "SerialPort": "COM7",

--- a/LEMP.Application/SmartMeter/SmartMeterAdapter.cs
+++ b/LEMP.Application/SmartMeter/SmartMeterAdapter.cs
@@ -1,4 +1,8 @@
 using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Text.Json;
 using LEMP.Application.Modbus;
 using LEMP.Domain.SmartMeter;
 
@@ -6,11 +10,34 @@ namespace LEMP.Application.SmartMeter;
 
 public class SmartMeterAdapter
 {
-    private readonly ModbusRTUReader _reader;
+    private static readonly IReadOnlyDictionary<string, Action<SmartMeterState, double>> FieldSetters =
+        new Dictionary<string, Action<SmartMeterState, double>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["voltagelinetoneutral"] = (s, v) => s.VoltageLineToNeutral = v,
+            ["current"] = (s, v) => s.Current = v,
+            ["activepower"] = (s, v) => s.ActivePower = v,
+            ["apparentpower"] = (s, v) => s.ApparentPower = v,
+            ["reactivepower"] = (s, v) => s.ReactivePower = v,
+            ["powerfactor"] = (s, v) => s.PowerFactor = v,
+            ["frequency"] = (s, v) => s.Frequency = v,
+            ["importedactiveenergy"] = (s, v) => s.ImportedActiveEnergy = v,
+            ["exportedactiveenergy"] = (s, v) => s.ExportedActiveEnergy = v,
+            ["importedreactiveenergy"] = (s, v) => s.ImportedReactiveEnergy = v,
+            ["exportedreactiveenergy"] = (s, v) => s.ExportedReactiveEnergy = v,
+            ["totalactiveenergy"] = (s, v) => s.TotalActiveEnergy = v
+        };
 
-    public SmartMeterAdapter(ModbusRTUReader reader)
+    private readonly ModbusRTUReader _reader;
+    private readonly IReadOnlyList<SmartMeterRegisterDefinition> _registers;
+
+    public SmartMeterAdapter(ModbusRTUReader reader, string mapPath)
     {
         _reader = reader;
+        _registers = LoadRegisterDefinitions(mapPath);
+        if (_registers.Count == 0)
+        {
+            throw new InvalidOperationException("No smart meter registers were loaded from the map file.");
+        }
     }
 
     public SmartMeterState ReadSmartMeterState()
@@ -18,25 +45,18 @@ public class SmartMeterAdapter
         var state = new SmartMeterState();
         bool allOk = true;
 
-        var requests = new List<RegisterReadRequest<float>>
+        foreach (var definition in _registers)
         {
-            new() { SlaveId = 1, StartAddress = 0,   RegisterCount = 2, FunctionCode = 4, OnValue = v => state.VoltageLineToNeutral = v },
-            new() { SlaveId = 1, StartAddress = 6,   RegisterCount = 2, FunctionCode = 4, OnValue = v => state.Current = v },
-            new() { SlaveId = 1, StartAddress = 12,  RegisterCount = 2, FunctionCode = 4, OnValue = v => state.ActivePower = v },
-            new() { SlaveId = 1, StartAddress = 18,  RegisterCount = 2, FunctionCode = 4, OnValue = v => state.ApparentPower = v },
-            new() { SlaveId = 1, StartAddress = 24,  RegisterCount = 2, FunctionCode = 4, OnValue = v => state.ReactivePower = v },
-            new() { SlaveId = 1, StartAddress = 30,  RegisterCount = 2, FunctionCode = 4, OnValue = v => state.PowerFactor = v },
-            new() { SlaveId = 1, StartAddress = 70,  RegisterCount = 2, FunctionCode = 4, OnValue = v => state.Frequency = v },
-            new() { SlaveId = 1, StartAddress = 72,  RegisterCount = 2, FunctionCode = 4, OnValue = v => state.ImportedActiveEnergy = v },
-            new() { SlaveId = 1, StartAddress = 74,  RegisterCount = 2, FunctionCode = 4, OnValue = v => state.ExportedActiveEnergy = v },
-            new() { SlaveId = 1, StartAddress = 76,  RegisterCount = 2, FunctionCode = 4, OnValue = v => state.ImportedReactiveEnergy = v },
-            new() { SlaveId = 1, StartAddress = 78,  RegisterCount = 2, FunctionCode = 4, OnValue = v => state.ExportedReactiveEnergy = v },
-            new() { SlaveId = 1, StartAddress = 342, RegisterCount = 2, FunctionCode = 4, OnValue = v => state.TotalActiveEnergy = v }
-        };
+            var request = new RegisterReadRequest<float>
+            {
+                SlaveId = definition.SlaveId,
+                StartAddress = definition.StartAddress,
+                RegisterCount = definition.RegisterCount,
+                FunctionCode = definition.FunctionCode,
+                OnValue = raw => definition.Apply(state, raw)
+            };
 
-        foreach (var req in requests)
-        {
-            if (!_reader.TryRead(req))
+            if (!_reader.TryRead(request))
             {
                 allOk = false;
             }
@@ -44,5 +64,199 @@ public class SmartMeterAdapter
 
         state.SmartMeterAlive = allOk;
         return state;
+    }
+
+    private static IReadOnlyList<SmartMeterRegisterDefinition> LoadRegisterDefinitions(string jsonPath)
+    {
+        if (!File.Exists(jsonPath))
+        {
+            throw new FileNotFoundException($"Smart meter mapping file not found: {jsonPath}");
+        }
+
+        var json = File.ReadAllText(jsonPath);
+        var options = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            ReadCommentHandling = JsonCommentHandling.Skip,
+            AllowTrailingCommas = true
+        };
+
+        var rows = JsonSerializer.Deserialize<List<SmartMeterJsonRow>>(json, options) ?? new List<SmartMeterJsonRow>();
+        var definitions = new List<SmartMeterRegisterDefinition>();
+
+        foreach (var row in rows)
+        {
+            if (!IsTrue(row.Active))
+            {
+                continue;
+            }
+
+            var fieldKey = Normalize(row.Name);
+            if (string.IsNullOrEmpty(fieldKey) || !FieldSetters.TryGetValue(fieldKey, out var setter))
+            {
+                continue;
+            }
+
+            if (!IsFloatDataType(row.DataType))
+            {
+                continue;
+            }
+
+            if (!ushort.TryParse(row.ReadAddress, NumberStyles.Integer, CultureInfo.InvariantCulture, out var address))
+            {
+                continue;
+            }
+
+            var registerCount = ParseRegisterCount(row.Length);
+            var functionCode = ParseByte(row.ReadFunctionCode, defaultValue: 4);
+            var slaveId = ParseByte(row.SlaveId, defaultValue: 1);
+            var factor = ParseFactor(row.Factor);
+
+            definitions.Add(new SmartMeterRegisterDefinition(
+                slaveId,
+                address,
+                registerCount,
+                functionCode,
+                factor,
+                setter));
+        }
+
+        return definitions;
+    }
+
+    private static bool IsTrue(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var normalized = value.Trim().ToLowerInvariant();
+        return normalized is "true" or "1" or "yes" or "y";
+    }
+
+    private static bool IsFloatDataType(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return true; // Default to float if unspecified.
+        }
+
+        var normalized = value.Trim().ToLowerInvariant();
+        return normalized is "float" or "float32" or "single";
+    }
+
+    private static ushort ParseRegisterCount(string? value)
+    {
+        if (!string.IsNullOrWhiteSpace(value)
+            && ushort.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
+            && parsed > 0)
+        {
+            return parsed;
+        }
+
+        return 2;
+    }
+
+    private static byte ParseByte(string? value, byte defaultValue)
+    {
+        if (!string.IsNullOrWhiteSpace(value)
+            && byte.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+        {
+            return parsed;
+        }
+
+        return defaultValue;
+    }
+
+    private static double ParseFactor(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return 1.0;
+        }
+
+        var trimmed = value.Trim();
+        if (trimmed.Contains('/', StringComparison.Ordinal))
+        {
+            double result = 1.0;
+            foreach (var part in trimmed.Split('/', StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (double.TryParse(part, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed))
+                {
+                    result *= parsed;
+                }
+            }
+
+            return result;
+        }
+
+        return double.TryParse(trimmed, NumberStyles.Float, CultureInfo.InvariantCulture, out var valueParsed)
+            ? valueParsed
+            : 1.0;
+    }
+
+    private static string Normalize(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        var sb = new StringBuilder(value.Length);
+        foreach (var ch in value)
+        {
+            if (char.IsLetterOrDigit(ch))
+            {
+                sb.Append(char.ToLowerInvariant(ch));
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private sealed class SmartMeterRegisterDefinition
+    {
+        private readonly Action<SmartMeterState, double> _setter;
+
+        public SmartMeterRegisterDefinition(
+            byte slaveId,
+            ushort startAddress,
+            ushort registerCount,
+            byte functionCode,
+            double factor,
+            Action<SmartMeterState, double> setter)
+        {
+            SlaveId = slaveId;
+            StartAddress = startAddress;
+            RegisterCount = registerCount;
+            FunctionCode = functionCode;
+            Factor = factor;
+            _setter = setter;
+        }
+
+        public byte SlaveId { get; }
+        public ushort StartAddress { get; }
+        public ushort RegisterCount { get; }
+        public byte FunctionCode { get; }
+        public double Factor { get; }
+
+        public void Apply(SmartMeterState state, float rawValue)
+        {
+            var scaled = rawValue * Factor;
+            _setter(state, scaled);
+        }
+    }
+
+    private sealed class SmartMeterJsonRow
+    {
+        public string? Active { get; set; }
+        public string? ReadFunctionCode { get; set; }
+        public string? ReadAddress { get; set; }
+        public string? Length { get; set; }
+        public string? Name { get; set; }
+        public string? DataType { get; set; }
+        public string? Factor { get; set; }
+        public string? SlaveId { get; set; }
     }
 }

--- a/LEMP.Infrastructure/Config/smd230smartmeter.json
+++ b/LEMP.Infrastructure/Config/smd230smartmeter.json
@@ -1,0 +1,134 @@
+[
+  {
+    "Active": "true",
+    "ReadFunctionCode": "4",
+    "ReadAddress": "0",
+    "Length": "2",
+    "Name": "VoltageLineToNeutral",
+    "DataType": "float32",
+    "Factor": "1",
+    "Unit": "V",
+    "Description": "Phase voltage measured between line and neutral."
+  },
+  {
+    "Active": "true",
+    "ReadFunctionCode": "4",
+    "ReadAddress": "6",
+    "Length": "2",
+    "Name": "Current",
+    "DataType": "float32",
+    "Factor": "1",
+    "Unit": "A",
+    "Description": "Current drawn on the measured phase."
+  },
+  {
+    "Active": "true",
+    "ReadFunctionCode": "4",
+    "ReadAddress": "12",
+    "Length": "2",
+    "Name": "ActivePower",
+    "DataType": "float32",
+    "Factor": "1",
+    "Unit": "W",
+    "Description": "Instantaneous active power."
+  },
+  {
+    "Active": "true",
+    "ReadFunctionCode": "4",
+    "ReadAddress": "18",
+    "Length": "2",
+    "Name": "ApparentPower",
+    "DataType": "float32",
+    "Factor": "1",
+    "Unit": "VA",
+    "Description": "Instantaneous apparent power."
+  },
+  {
+    "Active": "true",
+    "ReadFunctionCode": "4",
+    "ReadAddress": "24",
+    "Length": "2",
+    "Name": "ReactivePower",
+    "DataType": "float32",
+    "Factor": "1",
+    "Unit": "var",
+    "Description": "Instantaneous reactive power."
+  },
+  {
+    "Active": "true",
+    "ReadFunctionCode": "4",
+    "ReadAddress": "30",
+    "Length": "2",
+    "Name": "PowerFactor",
+    "DataType": "float32",
+    "Factor": "1",
+    "Unit": "",
+    "Description": "Power factor of the measured phase."
+  },
+  {
+    "Active": "true",
+    "ReadFunctionCode": "4",
+    "ReadAddress": "70",
+    "Length": "2",
+    "Name": "Frequency",
+    "DataType": "float32",
+    "Factor": "1",
+    "Unit": "Hz",
+    "Description": "Measured grid frequency."
+  },
+  {
+    "Active": "true",
+    "ReadFunctionCode": "4",
+    "ReadAddress": "72",
+    "Length": "2",
+    "Name": "ImportedActiveEnergy",
+    "DataType": "float32",
+    "Factor": "1",
+    "Unit": "kWh",
+    "Description": "Cumulative imported active energy."
+  },
+  {
+    "Active": "true",
+    "ReadFunctionCode": "4",
+    "ReadAddress": "74",
+    "Length": "2",
+    "Name": "ExportedActiveEnergy",
+    "DataType": "float32",
+    "Factor": "1",
+    "Unit": "kWh",
+    "Description": "Cumulative exported active energy."
+  },
+  {
+    "Active": "true",
+    "ReadFunctionCode": "4",
+    "ReadAddress": "76",
+    "Length": "2",
+    "Name": "ImportedReactiveEnergy",
+    "DataType": "float32",
+    "Factor": "1",
+    "Unit": "kvarh",
+    "Description": "Cumulative imported reactive energy."
+  },
+  {
+    "Active": "true",
+    "ReadFunctionCode": "4",
+    "ReadAddress": "78",
+    "Length": "2",
+    "Name": "ExportedReactiveEnergy",
+    "DataType": "float32",
+    "Factor": "1",
+    "Unit": "kvarh",
+    "Description": "Cumulative exported reactive energy."
+  },
+  {
+    "Active": "true",
+    "ReadFunctionCode": "4",
+    "ReadAddress": "342",
+    "Length": "2",
+    "Name": "TotalActiveEnergy",
+    "DataType": "float32",
+    "Factor": "1",
+    "Unit": "kWh",
+    "Description": "Total cumulative active energy."
+  }
+]

--- a/LEMP.Infrastructure/LEMP.Infrastructure.csproj
+++ b/LEMP.Infrastructure/LEMP.Infrastructure.csproj
@@ -25,6 +25,9 @@
     <None Update="Config/deyemodbus.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Config/smd230smartmeter.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- add an SMD230 smart meter mapping file and copy it to the output directory
- update the smart meter adapter to parse register definitions from the configurable JSON map
- configure the smart meter service to use the new map file when polling and forwarding metrics

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68da8d22f454832d821442824f6b70bf